### PR TITLE
Update server.go

### DIFF
--- a/tritter/server/server.go
+++ b/tritter/server/server.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	listenAddr = "localhost:50051"
+var (
+	listenAddr = flag.String("listen_addr", "localhost:50051", "the address the server is listening on")
 )
 
 // server is used to implement TritterServer.


### PR DESCRIPTION
Would like to be able to pass server address. To serve on VM's external IP, listenAddr needs to be internal IP of VM, which is only known once VM is spun up.